### PR TITLE
Default Logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,27 @@ log = l5g.Logger(LogDebug).ToRemoteSyslog(l5g.SyslogLocal2, "myapp", "tcp", "sys
 ```
 Note: All syslog logging priorities are supported. Fatal() will log as EMERG. Otherwise, the naming is 1:1.
 
+Default Logger
+--------------
+
+A default logger is availabe via `GetLogger(key string)` and is configured from environment variables. If no log5go environment variables are set this logger defaults to logging to stdout and stderr. Log messages are prefixed with `key`.
+
+Example:
+
+```go
+log = l5g.GetLogger("foo")
+
+log.Info("some information worth logging.")
+```
+
+The following environment variables can be used to configure default loggers:
+* L5G_LOG_FILE_NAME - The full path to the logfile to log to. If this environment variable is not set the default logger will log to stdout and stderr.
+* L5G_LOG_LEVEL - The level: ALL, TRACE, DEBUG, INFO, NOTICE, WARN, ERROR, CRIT, ALERT, or FATAL.
+* L5G_LOG_LINE_LENGTH - LONG, SHORT, or NONE. SHORT includes the name of the source file and line number, LONG includes the full path to source and line number, NONE excludes source and line number information in log messages.
+* L5G_LOG_FILE_ROTATION_FREQUENCY - NONE, MINUTE, HOUR, DAY or WEEK. Frequency to rotate log files.
+* L5G_LOG_FILE_ROTATION_KEEP_N_FILES - Number of previous log files to keep.
+
+
 Features
 ========
 

--- a/default.go
+++ b/default.go
@@ -24,7 +24,7 @@ type logconf struct {
 	logLineLength        string
 }
 
-var lock = sync.RWMutex{}
+var lock = sync.Mutex{}
 var conf *logconf
 
 func GetConsoleLogger() (l Log5Go) {

--- a/default.go
+++ b/default.go
@@ -6,8 +6,9 @@ import (
 )
 
 const (
-	L5G_LOG_FILE_NAME = "L5G_LOG_FILE_NAME"
-	L5G_LOG_LEVEL     = "L5G_LOG_LEVEL"
+	L5G_LOG_FILE_NAME   = "L5G_LOG_FILE_NAME"
+	L5G_LOG_LEVEL       = "L5G_LOG_LEVEL"
+	L5G_LOG_LINE_LENGTH = "L5G_LOG_LINE_LENGTH"
 )
 
 func GetLogger(key string) (l Log5Go) {
@@ -26,6 +27,17 @@ func createLogFromEnvVars() (l Log5Go) {
 	} else {
 		// default to Stdout
 		l.ToStdout().WithStderr()
+	}
+
+	switch os.Getenv(L5G_LOG_LINE_LENGTH) {
+	case "NONE":
+		// no-op
+	case "LONG":
+		l.WithLongLines()
+	case "SHORT":
+		l.WithShortLines()
+	case "":
+		l.WithShortLines()
 	}
 
 	return

--- a/default.go
+++ b/default.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 )
 
 const (
@@ -14,6 +15,25 @@ const (
 	L5G_LOG_FILE_ROTATION_KEEP_N_FILES = "L5G_LOG_FILE_ROTATION_KEEP_N_FILES"
 )
 
+type logconf struct {
+	logLevel             LogLevel
+	logFilePath          string
+	logFileName          string
+	logFileRollFrequency rollFrequency
+	keepNFiles           int
+	logLineLength        string
+}
+
+var lock = sync.RWMutex{}
+var conf *logconf
+
+func GetConsoleLogger() (l Log5Go) {
+	l = GetOrCreate("console", func() (_ Log5Go) {
+		return Logger(LogAll).ToStdout()
+	})
+	return
+}
+
 func GetLogger(key string) (l Log5Go) {
 	l = GetOrCreate(key, func() (_ Log5Go) {
 		return createLogFromEnvVars()
@@ -21,54 +41,85 @@ func GetLogger(key string) (l Log5Go) {
 	return
 }
 
-func createLogFromEnvVars() (l Log5Go) {
-	l = getBaseLogWithLevel(os.Getenv(L5G_LOG_LEVEL))
+func loadEnv() {
+	lock.Lock()
+	defer lock.Unlock()
 
-	path, file := parseFilenameAndPath(os.Getenv(L5G_LOG_FILE_NAME))
-	if path != "" && file != "" {
-		l.ToFile(path, file)
+	if conf == nil {
+		console := GetConsoleLogger()
+		console.Info("Initializing Log5Go ... ")
 
-		n := parseKeepNFilesInt(os.Getenv(L5G_LOG_FILE_ROTATION_KEEP_N_FILES))
-		// file rotation
-		switch os.Getenv(L5G_LOG_FILE_ROTATION_FREQUENCY) {
-		case "MINUTE":
-			l.WithRotation(RollMinutely, n)
-		case "HOUR":
-			l.WithRotation(RollHourly, n)
-		case "DAY":
-			l.WithRotation(RollDaily, n)
-		case "WEEK":
-			l.WithRotation(RollWeekly, n)
+		conf = &logconf{
+			logLevel: parseLogLevel(os.Getenv(L5G_LOG_LEVEL)),
 		}
 
+		console.Info("[Log Level: %v]", levelMap[conf.logLevel])
+
+		conf.logFilePath, conf.logFileName = parseFilenameAndPath(os.Getenv(L5G_LOG_FILE_NAME))
+		if conf.logFilePath != "" && conf.logFileName != "" {
+			console.Info("[Logging to file: %s/%s]", conf.logFilePath, conf.logFileName)
+			conf.keepNFiles = parseKeepNFilesInt(os.Getenv(L5G_LOG_FILE_ROTATION_KEEP_N_FILES))
+			logFileRollFrequency, rollLabel := parseFileRotationFrequency(os.Getenv(L5G_LOG_FILE_ROTATION_FREQUENCY))
+			conf.logFileRollFrequency = logFileRollFrequency
+
+			console.Info("[Logfile Roll Frequency: %s]", rollLabel)
+			console.Info("[Logfiles to keep: %d]", conf.keepNFiles)
+
+		} else {
+			console.Info("[Logging to Stdout]")
+		}
+
+		conf.logLineLength = parseLogLineLength(os.Getenv(L5G_LOG_LINE_LENGTH))
+		console.Info("[Log Line Length: %s]", conf.logLineLength)
+	}
+}
+
+func createLogFromEnvVars() (l Log5Go) {
+	loadEnv()
+
+	// create a base Log5Go with the appropriate log level
+	l = Logger(conf.logLevel)
+
+	if conf.logFilePath != "" && conf.logFileName != "" {
+		l.ToFile(conf.logFilePath, conf.logFileName)
+
+		// file rotation
+		if conf.logFileRollFrequency != RollNone {
+			l.WithRotation(conf.logFileRollFrequency, conf.keepNFiles)
+		}
 	} else {
 		// default to Stdout
 		l.ToStdout().WithStderr()
 	}
 
-	switch os.Getenv(L5G_LOG_LINE_LENGTH) {
-	case "NONE":
-		// no-op
+	switch conf.logLineLength {
 	case "LONG":
 		l.WithLongLines()
-	case "SHORT":
-		l.WithShortLines()
-	case "":
+	case "SHORT", "NONE":
 		l.WithShortLines()
 	}
 
 	return
 }
 
-func getBaseLogWithLevel(loglevel string) (l Log5Go) {
+func parseLogLineLength(token string) (str string) {
+	str = "NONE"
+	switch token {
+	case "LONG", "SHORT":
+		str = token
+	}
+	return str
+}
+
+func parseLogLevel(logLevelStr string) (level LogLevel) {
 	for k, v := range levelMap {
-		if v == loglevel {
-			l = Logger(k)
+		if v == logLevelStr {
+			level = k
 			return
 		}
 	}
 
-	l = Logger(LogAll)
+	level = LogAll
 	return
 }
 
@@ -86,6 +137,26 @@ func parseFilenameAndPath(fullname string) (path, filename string) {
 	path = fullname[:i]
 	filename = fullname[i+1:]
 	return
+}
+
+func parseFileRotationFrequency(str string) (freq rollFrequency, label string) {
+	label = str
+	switch str {
+	case "MINUTE":
+		freq = RollMinutely
+		return
+	case "HOUR":
+		freq = RollHourly
+		return
+	case "DAY":
+		freq = RollDaily
+		return
+	case "WEEK":
+		freq = RollWeekly
+		return
+	}
+
+	return RollNone, "NONE"
 }
 
 func parseKeepNFilesInt(str string) (i int) {

--- a/default.go
+++ b/default.go
@@ -1,0 +1,60 @@
+package log5go
+
+import (
+	"os"
+	"strings"
+)
+
+const (
+	L5G_LOG_FILE_NAME = "L5G_LOG_FILE_NAME"
+	L5G_LOG_LEVEL     = "L5G_LOG_LEVEL"
+)
+
+func GetLogger(key string) (l Log5Go) {
+	l = GetOrCreate(key, func() (_ Log5Go) {
+		return createLogFromEnvVars()
+	}).WithPrefix(key)
+	return
+}
+
+func createLogFromEnvVars() (l Log5Go) {
+	l = getBaseLogWithLevel(os.Getenv(L5G_LOG_LEVEL))
+
+	path, file := parseFilenameAndPath(os.Getenv(L5G_LOG_FILE_NAME))
+	if path != "" && file != "" {
+		l.ToFile(path, file)
+	} else {
+		// default to Stdout
+		l.ToStdout().WithStderr()
+	}
+
+	return
+}
+
+func getBaseLogWithLevel(loglevel string) (l Log5Go) {
+	for k, v := range levelMap {
+		if v == loglevel {
+			l = Logger(k)
+			return
+		}
+	}
+
+	l = Logger(LogAll)
+	return
+}
+
+func parseFilenameAndPath(fullname string) (path, filename string) {
+	if "" == fullname {
+		return
+	}
+
+	i := strings.LastIndex(fullname, "/")
+
+	if i+1 == len(fullname) {
+		return
+	}
+
+	path = fullname[:i]
+	filename = fullname[i+1:]
+	return
+}

--- a/default_test.go
+++ b/default_test.go
@@ -37,3 +37,19 @@ func Test_parseFilenameAndPath_TraliningSlash(t *testing.T) {
 	assert.Equal(t, "", path)
 	assert.Equal(t, "", file)
 }
+
+func Test_parseKeepNFilesInt_Empty(t *testing.T) {
+	assert.Equal(t, 1, parseKeepNFilesInt(""))
+}
+
+func Test_parseKeepNFilesInt_10(t *testing.T) {
+	assert.Equal(t, 10, parseKeepNFilesInt("10"))
+}
+
+func Test_parseKeepNFilesInt_1(t *testing.T) {
+	assert.Equal(t, 1, parseKeepNFilesInt("1"))
+}
+
+func Test_parseKeepNFilesInt_NotNumeric(t *testing.T) {
+	assert.Equal(t, 1, parseKeepNFilesInt("foobar"))
+}

--- a/default_test.go
+++ b/default_test.go
@@ -1,0 +1,39 @@
+package log5go
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getBaseLogWithLevel_Default(t *testing.T) {
+	l := getBaseLogWithLevel("")
+	if assert.NotNil(t, l) {
+		assert.Equal(t, LogAll, l.LogLevel())
+	}
+}
+
+func Test_getBaseLogWithLevel_LogNotice(t *testing.T) {
+	l := getBaseLogWithLevel("NOTICE")
+	if assert.NotNil(t, l) {
+		assert.Equal(t, LogNotice, l.LogLevel())
+	}
+}
+
+func Test_parseFilenameAndPath_Empty(t *testing.T) {
+	path, file := parseFilenameAndPath("")
+	assert.Equal(t, "", path)
+	assert.Equal(t, "", file)
+}
+
+func Test_parseFilenameAndPath_HappyPath(t *testing.T) {
+	path, file := parseFilenameAndPath("/foo/1/bar")
+	assert.Equal(t, "/foo/1", path)
+	assert.Equal(t, "bar", file)
+}
+
+func Test_parseFilenameAndPath_TraliningSlash(t *testing.T) {
+	path, file := parseFilenameAndPath("/foo/bar/")
+	assert.Equal(t, "", path)
+	assert.Equal(t, "", file)
+}

--- a/default_test.go
+++ b/default_test.go
@@ -6,18 +6,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_getBaseLogWithLevel_Default(t *testing.T) {
-	l := getBaseLogWithLevel("")
-	if assert.NotNil(t, l) {
-		assert.Equal(t, LogAll, l.LogLevel())
-	}
+func Test_parseLogLevel_Default(t *testing.T) {
+	assert.Equal(t, LogAll, parseLogLevel(""))
 }
 
-func Test_getBaseLogWithLevel_LogNotice(t *testing.T) {
-	l := getBaseLogWithLevel("NOTICE")
-	if assert.NotNil(t, l) {
-		assert.Equal(t, LogNotice, l.LogLevel())
-	}
+func Test_parseLogLevel_LogNotice(t *testing.T) {
+	assert.Equal(t, LogNotice, parseLogLevel("NOTICE"))
 }
 
 func Test_parseFilenameAndPath_Empty(t *testing.T) {
@@ -52,4 +46,24 @@ func Test_parseKeepNFilesInt_1(t *testing.T) {
 
 func Test_parseKeepNFilesInt_NotNumeric(t *testing.T) {
 	assert.Equal(t, 1, parseKeepNFilesInt("foobar"))
+}
+
+func Test_parseLogLineLength_Default(t *testing.T) {
+	assert.Equal(t, "NONE", parseLogLineLength(""))
+}
+
+func Test_parseLogLineLength_Bad(t *testing.T) {
+	assert.Equal(t, "NONE", parseLogLineLength("FOO"))
+}
+
+func Test_parseLogLineLength_None(t *testing.T) {
+	assert.Equal(t, "NONE", parseLogLineLength("NONE"))
+}
+
+func Test_parseLogLineLength_Long(t *testing.T) {
+	assert.Equal(t, "LONG", parseLogLineLength("LONG"))
+}
+
+func Test_parseLogLineLength_Short(t *testing.T) {
+	assert.Equal(t, "SHORT", parseLogLineLength("SHORT"))
 }

--- a/fileappender.go
+++ b/fileappender.go
@@ -11,7 +11,7 @@ import (
 type fileAppender struct {
 	lock          sync.Mutex
 	f             *os.File
-	fname					string 				// full path to file
+	fname         string // full path to file
 	lastOpenTime  time.Time
 	nextRollTime  time.Time
 	rollFrequency rollFrequency
@@ -101,7 +101,7 @@ func (a *fileAppender) shouldAttemptFileReopen() bool {
 
 func (a *fileAppender) reopenFile() {
 	a.lastOpenTime = time.Now()
-	newFile, err := os.OpenFile(a.fname, os.O_APPEND | os.O_WRONLY | os.O_CREATE, 0666)
+	newFile, err := os.OpenFile(a.fname, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0666)
 	if err == nil {
 		a.f = newFile
 	} else {

--- a/fileappender_test.go
+++ b/fileappender_test.go
@@ -45,12 +45,12 @@ func TestWatchFiles(t *testing.T) {
 		t.Errorf("error opening test file: %v", err)
 	}
 	a := &fileAppender{
-		f: logfile,
-		fname: fname,
-		lastOpenTime: time.Now(),
-		nextRollTime: time.Now(),
+		f:             logfile,
+		fname:         fname,
+		lastOpenTime:  time.Now(),
+		nextRollTime:  time.Now(),
 		rollFrequency: RollNone,
-		keepNLogs: SaveAllLogs,
+		keepNLogs:     SaveAllLogs,
 	}
 	fileAppenderMap[fname] = a
 
@@ -76,12 +76,12 @@ func TestAutoReopen(t *testing.T) {
 		t.Errorf("error opening test file: %v", err)
 	}
 	a := &fileAppender{
-		f: logfile,
-		fname: fname,
-		lastOpenTime: time.Now(),
-		nextRollTime: time.Now(),
+		f:             logfile,
+		fname:         fname,
+		lastOpenTime:  time.Now(),
+		nextRollTime:  time.Now(),
 		rollFrequency: RollNone,
-		keepNLogs: SaveAllLogs,
+		keepNLogs:     SaveAllLogs,
 	}
 	fileAppenderMap[fname] = a
 


### PR DESCRIPTION
Implements a default logger that can be configured from environment variables.

Utilizes logger registry by providing a `GetLogger()` function which wraps `GetOrCreateLogger()` with a passed in closure that creates a new Log5Go based on config specified as environment variables. 
